### PR TITLE
Explicitly set compression ratio on resulting jar files

### DIFF
--- a/src/main/java/net/minecraftforge/jarsplitter/ConsoleTool.java
+++ b/src/main/java/net/minecraftforge/jarsplitter/ConsoleTool.java
@@ -111,6 +111,9 @@ public class ConsoleTool {
                  ZipOutputStream zslim = new ZipOutputStream(slim == null ? NULL_OUTPUT : new FileOutputStream(slim));
                  ZipOutputStream zdata = new ZipOutputStream(data == null ? NULL_OUTPUT : new FileOutputStream(data));
                  ZipOutputStream zextra = new ZipOutputStream(extra == null ? NULL_OUTPUT : new FileOutputStream(extra))) {
+                zslim.setLevel(6);
+                zdata.setLevel(6);
+                zextra.setLevel(6);
 
                ZipEntry entry;
                while ((entry = zinput.getNextEntry()) != null) {

--- a/src/main/java/net/minecraftforge/jarsplitter/ConsoleTool.java
+++ b/src/main/java/net/minecraftforge/jarsplitter/ConsoleTool.java
@@ -111,6 +111,8 @@ public class ConsoleTool {
                  ZipOutputStream zslim = new ZipOutputStream(slim == null ? NULL_OUTPUT : new FileOutputStream(slim));
                  ZipOutputStream zdata = new ZipOutputStream(data == null ? NULL_OUTPUT : new FileOutputStream(data));
                  ZipOutputStream zextra = new ZipOutputStream(extra == null ? NULL_OUTPUT : new FileOutputStream(extra))) {
+                // Explicitly set compression level because of potential differences based on environment.
+                // See https://github.com/MinecraftForge/JarSplitter/pull/2
                 zslim.setLevel(6);
                 zdata.setLevel(6);
                 zextra.setLevel(6);


### PR DESCRIPTION
Apparently there are some OpenJDK distributions or other circumstances where the default compression level for ZipOutputStream is different. This was reported at PolyMC https://github.com/PolyMC/PolyMC/issues/809, but a user on the Forge Discord could reliably reproduce the issue on their end, even without PolyMC and a completely cleaned `.minecraft` directory.
An installer with this change allowed them to install normally. 
I have not been able to replicate this issue myself, but that is mostly because I did not take the time to go through the trouble of installing Arch Linux (where the issue was reported).
